### PR TITLE
Remove github-issues.vim

### DIFF
--- a/vimrc-deps
+++ b/vimrc-deps
@@ -40,7 +40,6 @@ Plugin 'JulesWang/css.vim'
 Plugin 'cakebaker/scss-syntax.vim'
 Plugin 'puppetlabs/puppet-syntax-vim'
 Plugin 'Valloric/YouCompleteMe'
-Plugin 'jaxbot/github-issues.vim'
 Plugin 'docker/docker' , {'rtp': '/contrib/syntax/vim/'}
 
 call vundle#end()


### PR DESCRIPTION
This was the cause of the slow down because `github-issues.vim` performs network calls. The convenience of this plugin is incomparable to the amount of productivity loss due to its slowness. I don't even use it as much anyway.
